### PR TITLE
Allow an iOS version to be specified as per the README

### DIFF
--- a/src/main/java/com/brewinapps/ios/IOSBuildMojo.java
+++ b/src/main/java/com/brewinapps/ios/IOSBuildMojo.java
@@ -63,11 +63,19 @@ public class IOSBuildMojo extends AbstractMojo {
 	 * 		default-value="Release"
 	 */
 	private String configuration;
+
+	/**
+	 * iOS version 
+	 * @parameter
+	 * 		expression="${ios.version}"
+	 */
+	private String version;
 	
 	/**
 	 * build id
 	 * @parameter
-	 * 		expression="${ios.buildId}"
+	 * 		expression="${ios.buildId}" 
+	 * 		default-value="${project.version}"
 	 */
 	private String buildId;	
 		
@@ -96,7 +104,7 @@ public class IOSBuildMojo extends AbstractMojo {
 			properties.put("targetDir", targetDir);
 			properties.put("configuration", configuration);
 			properties.put("buildId", buildId);
-			properties.put("version", project.getVersion());
+			properties.put("version", version);
 			properties.put("scheme", scheme);
 			
 			ProjectBuilder.build(properties);


### PR DESCRIPTION
The CFBundleShortVersionString is currently hard-coded to `${project.version}` so this patch allows it to be overridden by specifying `-Dios.version`.

It also defaults the CFBundleVersion to `${project.version}` so a buildId configuration is not mandatory.
